### PR TITLE
Collection of miscellaneous changes 

### DIFF
--- a/makefile.uni.py
+++ b/makefile.uni.py
@@ -41,9 +41,12 @@ from unibuild.projects import sevenzip, qt5, boost, zlib, python, sip, pyqt5
 from unibuild.projects import asmjit, udis86, googletest, spdlog, fmtlib, lz4, boostgit
 
 # TODO modorganizer-lootcli needs an overhaul as the api has changed alot
+def bitness():
+    return "x64" if config['architecture'] == "x86_64" else "Win32"
+	
 Project("LootApi") \
     .depend(patch.Copy("loot_api.dll".format(loot_version,commit_id), os.path.join(config['__build_base_path'], "install", "bin", "loot"))
-            .depend(github.Release("loot", "loot", loot_version, "loot-api_{}-0-{}_dev_x64".format(loot_version,commit_id),"7z",tree_depth=1)
+            .depend(github.Release("loot", "loot", loot_version, "loot-api_{}-0-{}_dev_{}".format(loot_version, commit_id, bitness()),"7z",tree_depth=1)
                     .set_destination("lootapi"))
            )
 
@@ -94,6 +97,7 @@ def gen_userfile_content(project):
 cmake_parameters = [
     "-DCMAKE_BUILD_TYPE={}".format(config["build_type"]),
     "-DDEPENDENCIES_DIR={}/build".format(config["__build_base_path"]),
+	"-DBOOST_ROOT={}/build/boost_{}".format(config["__build_base_path"], config["boost_version"].replace(".", "_")),
     "-DCMAKE_INSTALL_PREFIX:PATH={}/install".format(config["__build_base_path"])
 ]
 

--- a/unibuild/projects/cygwin.py
+++ b/unibuild/projects/cygwin.py
@@ -43,7 +43,7 @@ Cygwin_Mirror = "http://mirrors.kernel.org/sourceware/cygwin/"
 
 def build_func(context):
     proc = Popen([os.path.join(config['paths']['download'], filename),
-                   "-C", "Base", "-P", "make,dos2unix,binutils", "-n", "-d", "-O", "-B", "-R", "{}/../cygwin"
+                  "-q", "-C", "Base", "-P", "make,dos2unix,binutils", "-n", "-d", "-O", "-B", "-R", "{}/../cygwin"
                  .format(context['build_path']), "-l", "{}".format(os.path.join(config['paths']['download'])),
                   "-s", "{}".format(Cygwin_Mirror)],env=config['__environment'])
     proc.communicate()

--- a/unibuild/projects/qt5.py
+++ b/unibuild/projects/qt5.py
@@ -173,7 +173,7 @@ else:
 
     init_repo = build.Run("perl init-repository", name="init qt repository") \
         .set_fail_behaviour(Task.FailBehaviour.CONTINUE) \
-        .depend(git.Clone("git://code.qt.io/qt/qt5.git", qt_version))
+        .depend(git.Clone("http://code.qt.io/qt/qt5.git", qt_version))	# Internet proxy could refuse git protocol
 
     build_qt5 = build.Run(r"jom.exe -j {}".format(config['num_jobs']),
                           environment=qt5_environment(),

--- a/unimake.py
+++ b/unimake.py
@@ -153,7 +153,10 @@ def init_config(args):
     if 'PYTHON' not in config['__environment']:
         config['__environment']['PYTHON'] = sys.executable
 
-    qtcreator_config_path = r"C:/Users/modorganizer/AppData/Roaming/QtProject"
+    qtcreator_config_path = config['__environment']['AppData'] + "/QtProject"
+    logging.debug("  Profile: qtcreator_config_path=%s", qtcreator_config_path)
+    
+    # qtcreator_config_path = r"C:/Users/Tannin/AppData/Roaming/QtProject"
 
     if os.path.isdir(qtcreator_config_path):
         from ConfigParser import RawConfigParser


### PR DESCRIPTION
Restore LootApi compatibility with x86 architecture.
Force boost root in CMAKE configuration, I have a lot of issues with the automatic detection.
Restore -q argument to cygwin installation.
Change QT git repository address to http: from git: as some (mine :) ) internet proxy block the git protocol.
Select qt creator profile based on current user name.
