### PR TITLE
Aparently, QT 5.8 qmake only knows about win32-msvc (and no longer wi…

### DIFF
--- a/unibuild/projects/pyqt5.py
+++ b/unibuild/projects/pyqt5.py
@@ -82,7 +82,7 @@ class PyQt5Configure(build.Builder):
                               "-b", bp,
                               "-d", os.path.join(bp, "Lib", "site-packages"),
                               "-v", os.path.join(bp, "sip", "PyQt5"),
-                              "--sip-incdir", os.path.join(bp, "Include")],
+                              "--sip-incdir", os.path.join(bp, "Include"),
                              env=pyqt5_env(),
                              cwd=self._context["build_path"],
                              shell=True,


### PR DESCRIPTION
…n32-msvc20xx)

Consider adding also --verbose to see this error in the log.